### PR TITLE
pluginの更新をいい感じに

### DIFF
--- a/scripts/download_plugin.sh
+++ b/scripts/download_plugin.sh
@@ -50,13 +50,12 @@ function download_plugin(){
       FILE_VER=${VERSION#v}
       FILE_NAME=${FILE_NAME_PREFIX}${FILE_VER}
     elif [ "${FILE_VERSION_PREFIX}" == "no_version" ]; then
-       FILE_NAME=${FILE_NAME_PREFIX}
+      FILE_NAME=${FILE_NAME_PREFIX}
     elif [ "${FILE_VERSION_PREFIX}" == "none" ]; then
       FILE_NAME=${FILE_NAME_PREFIX}${VERSION}
     fi
     URL="https://github.com/${ORG}/${REPO}/releases/download/${VERSION}/${FILE_NAME}.jar"
     download()
-
   elif [ "${SOURCE}" == "opencollab" ]; then
       if [ "${FILE_VERSION_PREFIX}" == "no_version" ]; then
         FILE_NAME=${FILE_NAME_PREFIX}
@@ -67,7 +66,7 @@ function download_plugin(){
       URL="https://ci.opencollab.dev/job/${ORG}/job/${REPO}/job/master/lastSuccessfulBuild/artifact/${OPENCOLLAB_PREFIX}/${FILE_NAME}.jar"
       download()
     if [ ! $? -eq 0 ]; then
-      echo "FAILED: lastSuccess ${ORG}/${REPO} from openlab ."
+      echo "FAILED: lastSuccess ${ORG}/${REPO} from openlab."
       echo "retry fixed version"
       URL="https://ci.opencollab.dev/job/${ORG}/job/${REPO}/job/master/${VERSION}/artifact/${OPENCOLLAB_PREFIX}/${FILE_NAME}.jar"
       download()

--- a/scripts/download_plugin.sh
+++ b/scripts/download_plugin.sh
@@ -57,14 +57,29 @@ function download_plugin(){
     URL="https://github.com/${ORG}/${REPO}/releases/download/${VERSION}/${FILE_NAME}.jar"
     download
   elif [ "${SOURCE}" == "opencollab" ]; then
-      if [ "${FILE_VERSION_PREFIX}" == "no_version" ]; then
-        FILE_NAME=${FILE_NAME_PREFIX}
-      else
-        echo "not impl, please implement"
-        exit 1
-      fi
-      URL="https://ci.opencollab.dev/job/${ORG}/job/${REPO}/job/master/lastSuccessfulBuild/artifact/${OPENCOLLAB_PREFIX}/${FILE_NAME}.jar"
-      download
+    if [ "${FILE_VERSION_PREFIX}" == "no_version" ]; then
+      FILE_NAME=${FILE_NAME_PREFIX}
+    else
+      echo "not impl, please implement"
+      exit 1
+    fi
+    URL="https://ci.opencollab.dev/job/${ORG}/job/${REPO}/job/master/lastSuccessfulBuild/artifact/${OPENCOLLAB_PREFIX}/${FILE_NAME}.jar"
+
+
+    echo "${ORG}/${REPO} URL:${URL}"
+    # make file name
+    DAY=`date '+%F'`
+    LOCAL_FILE_NAME=${FILE_NAME_PREFIX%-}-latestbuild_${DAY}.jar
+    rm -rf "${FILE_NAME_PREFIX%-}"*.jar
+    wget -qO "$LOCAL_FILE_NAME" "$URL"
+    if [ $? -eq 0 ]; then
+      echo "SUCCESS:downloaded as ${LOCAL_FILE_NAME}"
+    else
+      echo "FAILED:${ORG}/${REPO} is faild."
+      exit 1
+    fi
+
+
     if [ ! $? -eq 0 ]; then
       echo "FAILED: lastSuccess ${ORG}/${REPO} from openlab."
       echo "retry fixed version"

--- a/scripts/download_plugin.sh
+++ b/scripts/download_plugin.sh
@@ -55,7 +55,7 @@ function download_plugin(){
       FILE_NAME=${FILE_NAME_PREFIX}${VERSION}
     fi
     URL="https://github.com/${ORG}/${REPO}/releases/download/${VERSION}/${FILE_NAME}.jar"
-    download()
+    download
   elif [ "${SOURCE}" == "opencollab" ]; then
       if [ "${FILE_VERSION_PREFIX}" == "no_version" ]; then
         FILE_NAME=${FILE_NAME_PREFIX}
@@ -64,12 +64,12 @@ function download_plugin(){
         exit 1
       fi
       URL="https://ci.opencollab.dev/job/${ORG}/job/${REPO}/job/master/lastSuccessfulBuild/artifact/${OPENCOLLAB_PREFIX}/${FILE_NAME}.jar"
-      download()
+      download
     if [ ! $? -eq 0 ]; then
       echo "FAILED: lastSuccess ${ORG}/${REPO} from openlab."
       echo "retry fixed version"
       URL="https://ci.opencollab.dev/job/${ORG}/job/${REPO}/job/master/${VERSION}/artifact/${OPENCOLLAB_PREFIX}/${FILE_NAME}.jar"
-      download()
+      download
     fi
   fi
 }
@@ -91,7 +91,7 @@ for item in "${PLUGINS[@]}"; do
   REPO=${ORG_REPO#*/}
   echo "---------------------------------------------------------------"
   echo "org_repo=$ORG_REPO, org=$ORG, repo=$REPO, ver=$VERSION, source=$SOURCE"
-  download_plugin()
+  download_plugin
   if [ ! $? -eq 0 ]; then
     echo "download failed"
     exit 1


### PR DESCRIPTION
プラグインの更新を分離
openlabのものは最新の成功ビルドを，無理ならバージョンを固定したものを落とす